### PR TITLE
Remove cueing restrictions

### DIFF
--- a/src/billard3d.c
+++ b/src/billard3d.c
@@ -2314,6 +2314,7 @@ VMfloat angle_pm90ud(VMfloat ang)
 
 void check_cue(void) {
 
+#ifdef CUEING_DOESNT_GET_STUCK_BY_BORDER_ANY_MORE
    int cue_ball = CUE_BALL_IND; // index cue-ball
    int i; //loop
    VMvect dir,cue_start_bande,nx,ny,pos,hitpoint;
@@ -2377,6 +2378,7 @@ void check_cue(void) {
         }
      }
    }
+#endif
 }
 
 /***********************************************************************


### PR DESCRIPTION
The master code restricts cueing near the border, whether or not the cue actually interferes with the table. This results in a playing experience that is needlessly frustrating.

Dodge the restrictive code, leaving restrictions to the player’s own judgement.